### PR TITLE
refactor: added exports for pagination prepare types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,10 @@
 
 import { composeWithPagination } from './composeWithPagination';
 import { preparePaginationResolver } from './paginationResolver';
+import { preparePaginationInfoTC, preparePaginationTC } from './types/preparePaginationType';
 
 export default composeWithPagination;
 
-export { composeWithPagination, preparePaginationResolver };
+export { composeWithPagination, preparePaginationResolver, preparePaginationInfoTC, preparePaginationTC };
 
 export type { ComposeWithPaginationOpts } from './paginationResolver';


### PR DESCRIPTION
I have a unique case where we don't want the resolver for the count to be separate from the pagination resolver itself since I am not hitting a DB but rather another REST endpoint that returns all the data.

I would much rather just use the prebuilt types you have for the `pageInfo` but need them to be exported. I think this would benefit a lot of people since this type is a standard. 