### PR TITLE
Separate pagination type fix

### DIFF
--- a/src/__tests__/pagination-test.ts
+++ b/src/__tests__/pagination-test.ts
@@ -61,10 +61,10 @@ describe('preparePaginationResolver()', () => {
       const anotherPaginationResolver = preparePaginationResolver(UserTC, {
         countResolver,
         findManyResolver,
-        name: 'otherPagination'
+        name: 'otherPagination',
       });
       expect(anotherPaginationResolver.getTypeName()).toBe('UserOtherPagination');
-    })
+    });
   });
 
   describe('resolver basic properties', () => {

--- a/src/__tests__/pagination-test.ts
+++ b/src/__tests__/pagination-test.ts
@@ -56,6 +56,15 @@ describe('preparePaginationResolver()', () => {
         })
       ).toThrowError("'opts.findManyResolver' must be a Resolver instance");
     });
+
+    it('should return a separate resolver with different type', () => {
+      const anotherPaginationResolver = preparePaginationResolver(UserTC, {
+        countResolver,
+        findManyResolver,
+        name: 'otherPagination'
+      });
+      expect(anotherPaginationResolver.getTypeName()).toBe('UserOtherPagination');
+    })
   });
 
   describe('resolver basic properties', () => {

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -85,7 +85,7 @@ export function preparePaginationResolver<TSource, TContext>(
   }
 
   return tc.schemaComposer.createResolver({
-    type: preparePaginationTC(tc),
+    type: preparePaginationTC(tc, resolverName),
     name: resolverName,
     kind: 'query',
     args: {


### PR DESCRIPTION
Hi @nodkz. I've faced issue using this package.

I have multiple pagination resolvers with one TC with little differences in output TC. When i try to fetch first pagination it replaces with last defined, because ```resolverName``` not used in output TC name.

Спасибо за либу 🙂 👍 