### PR TITLE
Wrong TC error text

### DIFF
--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -45,7 +45,7 @@ export function preparePaginationResolver<TSource, TContext>(
 ): Resolver<TSource, TContext, PaginationTArgs> {
   if (!tc || tc.constructor.name !== 'ObjectTypeComposer') {
     throw new Error(
-      'First arg for prepareConnectionResolver() should be instance of ObjectTypeComposer'
+      'First arg for preparePaginationResolver() should be instance of ObjectTypeComposer'
     );
   }
 


### PR DESCRIPTION
a little confusing when ```graphql-compose-pagination``` throws error about ```graphql-compose-connection```
especially when there is no ```graphql-compose-connection``` in project :)